### PR TITLE
add CI, convert to Arduino library

### DIFF
--- a/.arduino-ci.yaml
+++ b/.arduino-ci.yaml
@@ -1,0 +1,7 @@
+compile:
+  platforms:
+    - uno
+
+unittest:
+  platforms:
+    - uno

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.bin
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+script:
+   - bundle install
+   - bundle exec arduino_ci_remote.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'arduino_ci', '~> 0.1.7'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/sdesalas/Arduino-Queue.h.svg)](https://travis-ci.org/sdesalas/Arduino-Queue.h)
 # Queue.h
 
 [Generic](https://en.wikipedia.org/wiki/Generic_programming) C++ circular queue for Arduino embedded projects.

--- a/examples/queue_test/queue_test.ino
+++ b/examples/queue_test/queue_test.ino
@@ -28,7 +28,7 @@ void loop() {
     Serial.print(queue.peek());
     Serial.println("'.");
   } else {
-    Serial.println("Nothing to process..."); 
+    Serial.println("Nothing to process...");
   }
   delay(2000);
 }

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Queue
+version=0.0.1
+author=Steven de Salas <steven@desalasworks.com>
+maintainer=Steven de Salas <steven@desalasworks.com>
+sentence=Generic C++ circular queue
+paragraph=Works for any datatype and desired length
+category=Data Storage
+url=https://github.com/ifreecarve/arduino_ci/SampleProjects/DoSomething
+architectures=*
+includes=Queue.h

--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Steven de Salas <steven@desalasworks.com>
 sentence=Generic C++ circular queue
 paragraph=Works for any datatype and desired length
 category=Data Storage
-url=https://github.com/ifreecarve/arduino_ci/SampleProjects/DoSomething
+url=https://github.com/sdesalas/Arduino-Queue.h
 architectures=*
 includes=Queue.h

--- a/test/queue-tests.cpp
+++ b/test/queue-tests.cpp
@@ -1,0 +1,90 @@
+#include <ArduinoUnitTests.h>
+#include "../Queue.h"
+
+int testSize = 4; // number of elements we'll use in our test queues
+
+unittest(empty)
+{
+  Queue<int> queue(testSize);
+  assertEqual(0, queue.count()); // initially empty
+  assertEqual(0, queue.peek());  // 0 happens to be the default int val
+  assertEqual(0, queue.pop());
+  assertEqual(0, queue.count()); // still empty
+}
+
+unittest(filling_and_emptying)
+{
+  Queue<int> queue(testSize);
+  assertEqual(0,        queue.count()); // initially empty
+  for (int i = 1; i <= testSize; ++i) {
+    queue.push(i * 11);
+    assertEqual(i,            queue.count());  // count increases with pushes
+  }
+  for (int i = 1; i <= testSize; ++i) {
+    assertEqual(i * 11,           queue.peek());  // verify FIFO
+    assertEqual(testSize + 1 - i, queue.count()); // verify count unchanged
+    assertEqual(i * 11,           queue.pop());   // verify FIFO
+    assertEqual(testSize - i,     queue.count()); // verify count changed
+  }
+}
+
+unittest(filling_and_clearing)
+{
+  Queue<int> queue(testSize);
+  assertEqual(0, queue.count()); // initially empty
+  for (int i = 1; i <= testSize; ++i) {
+    queue.push(i * 11);
+    assertEqual(i, queue.count());      // count increases with pushes
+  }
+  assertEqual(testSize, queue.count()); // now full
+  queue.clear();
+  assertEqual(0,        queue.count()); // again empty
+}
+
+unittest(overfilling)
+{
+  Queue<int> queue(testSize);
+  assertEqual(0,        queue.count()); // initially empty
+  for (int i = 1; i <= testSize; ++i) {
+    queue.push(i * 11);
+  }
+  assertEqual(testSize, queue.count()); // now full
+  for (int i = (testSize + 1); i <= testSize * 2; ++i) {
+    queue.push(i * 11);
+    assertEqual(testSize, queue.count()); // still full
+  }
+
+  for (int i = 1; i <= testSize; ++i) {
+    assertEqual(i * 11,           queue.peek());  // verify FIFO
+    assertEqual(testSize + 1 - i, queue.count()); // verify count unchanged
+    assertEqual(i * 11,           queue.pop());   // verify FIFO
+    assertEqual(testSize - i,     queue.count()); // verify count changed
+  }
+}
+
+unittest(wrapping)
+{
+  Queue<int> queue(testSize);
+  queue.push(0); // offset the queue so we have to wrap around
+  queue.push(1);
+  queue.pop();
+  queue.pop();
+
+  for (int i = 1; i <= testSize; ++i) {
+    queue.push(i * 11);
+  }
+  assertEqual(testSize, queue.count()); // now full
+  for (int i = (testSize + 1); i <= testSize * 2; ++i) {
+    queue.push(i * 11);
+    assertEqual(testSize, queue.count()); // still full
+  }
+
+  for (int i = 1; i <= testSize; ++i) {
+    assertEqual(i * 11,           queue.peek());  // verify FIFO
+    assertEqual(testSize + 1 - i, queue.count()); // verify count unchanged
+    assertEqual(i * 11,           queue.pop());   // verify FIFO
+    assertEqual(testSize - i,     queue.count()); // verify count changed
+  }
+}
+
+unittest_main()


### PR DESCRIPTION
I'm working on a [library](https://github.com/ianfixes/arduino_ci) that allows you to run unit tests and compiling examples on Travis CI.  I'm using your project to shake some of the bugs out of my implementation, so I'm contributing my edits in case you think they would be useful.

Since you don't have Travis CI enabled for this repository, you'll have to peek at mine to see the results:
https://travis-ci.org/ianfixes/Arduino-Queue.h/builds